### PR TITLE
Add support for filtering tests by name in go test execution

### DIFF
--- a/py/atlas_init/__init__.py
+++ b/py/atlas_init/__init__.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-VERSION = "0.3.4"
+VERSION = "0.3.5"
 
 
 def running_in_repo() -> bool:

--- a/py/atlas_init/cli_helper/go.py
+++ b/py/atlas_init/cli_helper/go.py
@@ -66,6 +66,7 @@ def run_go_tests(
     concurrent_runs: int = 20,
     re_run: bool = False,
     env_vars: GoEnvVars = GoEnvVars.vscode,
+    names: set[str] | None = None,
 ) -> GoTestResult:
     test_env = _resolve_env_vars(settings, env_vars)
     if ci_value := test_env.pop("CI", None):
@@ -84,10 +85,13 @@ def run_go_tests(
                 concurrent_runs = 1
             test_names = find_individual_tests(repo_path, package_paths)
             for name, pkg_path in test_names.items():
+                if names and name not in names:
+                    continue
                 results.add_test_package_path(name, pkg_path)
                 commands_to_run[name] = f"go test {packages} -v -run ^{name}$ -timeout {timeout_minutes}m"
         elif mode == GoTestMode.package:
-            command = f"go test {packages} -v -run ^TestAcc* -timeout {timeout_minutes}m"
+            name_regex = "^TestAcc*" if names is None else f'^({"|".join(names)})$'
+            command = f"go test {packages} -v -run {name_regex} -timeout {timeout_minutes}m"
             if not group.sequential_tests:
                 command = f"{command} -parallel {concurrent_runs}"
             commands_to_run[group.name] = command

--- a/py/atlas_init/cli_helper/go.py
+++ b/py/atlas_init/cli_helper/go.py
@@ -90,7 +90,7 @@ def run_go_tests(
                 results.add_test_package_path(name, pkg_path)
                 commands_to_run[name] = f"go test {packages} -v -run ^{name}$ -timeout {timeout_minutes}m"
         elif mode == GoTestMode.package:
-            name_regex = "^TestAcc*" if names is None else f'^({"|".join(names)})$'
+            name_regex = f'^({"|".join(names)})$' if names else "^TestAcc*"
             command = f"go test {packages} -v -run {name_regex} -timeout {timeout_minutes}m"
             if not group.sequential_tests:
                 command = f"{command} -parallel {concurrent_runs}"

--- a/py/atlas_init/cli_root/go_test.py
+++ b/py/atlas_init/cli_root/go_test.py
@@ -23,6 +23,9 @@ def go_test(
         False, "--export-verbose", help="log roundtrips when exporting the mock-tf-log"
     ),
     env_method: GoEnvVars = typer.Option(GoEnvVars.manual, "--env", help="|".join(list(GoEnvVars))),
+    names: list[str] = typer.Option(
+        ..., "-n", "--names", default_factory=list, help="run only the tests with these names"
+    ),
 ):
     if export_mock_tf_log and mode != GoTestMode.individual:
         err_msg = "exporting mock-tf-log is only supported for individual tests"
@@ -50,6 +53,7 @@ def go_test(
                 concurrent_runs=concurrent_runs,
                 re_run=re_run,
                 env_vars=env_method,
+                names=set(names),
             )
         case _:
             raise NotImplementedError


### PR DESCRIPTION
Introduce functionality to run specific tests by name, allowing users to filter test execution based on provided names.