### PR TITLE
Add package_must_substrings function for enhanced filtering in MockTFLog

### DIFF
--- a/py/atlas_init/__init__.py
+++ b/py/atlas_init/__init__.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-VERSION = "0.3.5"
+VERSION = "0.3.6"
 
 
 def running_in_repo() -> bool:

--- a/py/atlas_init/cli_tf/debug_logs_test_data_package_config.py
+++ b/py/atlas_init/cli_tf/debug_logs_test_data_package_config.py
@@ -46,3 +46,10 @@ def package_skip_suffixes(pkg_name: str) -> list[str]:
     if pkg_name == "resourcepolicy":
         return [":validate"]
     return []
+
+
+def package_must_substrings(pkg_name: str) -> list[str]:
+    # sourcery skip: assign-if-exp, reintroduce-else
+    if pkg_name == "advancedcluster":
+        return ["/clusters"]
+    return []


### PR DESCRIPTION
Introduce a new function to filter packages based on required substrings and integrate it into the MockTFLog class for improved functionality. Update the version to 0.3.6.