### PR TITLE
Make package name prompt mandatory and improve test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 *.tfstate*
 *.code-workspace
 *.auto.tfvars
-dev.tfrc
+dev*.tfrc
 *.env-generated
 *.env
 *.env_manual

--- a/py/atlas_init/cli_cfn/example.py
+++ b/py/atlas_init/cli_cfn/example.py
@@ -53,6 +53,9 @@ class CfnExampleInputs(CfnType):
         assert self.region_filter, "region is required"
         assert self.execution_role.startswith("arn:aws:iam::"), f"invalid execution role: {self.execution_role}"
         assert self.region
+        if self.delete_stack_first and self.operation == Operation.UPDATE:
+            err_msg = "cannot delete first when updating"
+            raise ValueError(err_msg)
         return self
 
     @property

--- a/py/atlas_init/cli_root/go_test.py
+++ b/py/atlas_init/cli_root/go_test.py
@@ -26,6 +26,7 @@ def go_test(
     names: list[str] = typer.Option(
         ..., "-n", "--names", default_factory=list, help="run only the tests with these names"
     ),
+    use_replay_mode: bool = typer.Option(False, "--replay", help="use replay mode and stored responses"),
 ):
     if export_mock_tf_log and mode != GoTestMode.individual:
         err_msg = "exporting mock-tf-log is only supported for individual tests"
@@ -54,6 +55,7 @@ def go_test(
                 re_run=re_run,
                 env_vars=env_method,
                 names=set(names),
+                use_replay_mode=use_replay_mode,
             )
         case _:
             raise NotImplementedError

--- a/py/atlas_init/cli_tf/github_logs.py
+++ b/py/atlas_init/cli_tf/github_logs.py
@@ -222,7 +222,8 @@ def select_step_and_log_content(job: WorkflowJob, logs_path: Path) -> tuple[int,
 
 def test_step(steps: list[WorkflowStep]) -> int:
     for i, step in enumerate(steps, 1):
-        if "test" in step.name.lower():
+        name_lower = step.name.lower()
+        if "acceptance test" in name_lower and "mocked" not in name_lower:
             return i
     last_step = len(steps)
     logger.warning(f"using {last_step} as final step, unable to find 'test' in {steps}")

--- a/py/atlas_init/cli_tf/mock_tf_log.py
+++ b/py/atlas_init/cli_tf/mock_tf_log.py
@@ -128,7 +128,7 @@ def mock_tf_log_cmd(
     log_diff_roundtrips: bool = typer.Option(
         False, "-l", "--log-diff-roundtrips", help="print out the roundtrips used in diffs"
     ),
-    package_name: str = typer.Option("", "-p", "--package-name", help="the package name to use for modifiers"),
+    package_name: str = typer.Option("-p", "--package-name", prompt=True, help="the package name to use for modifiers"),
 ):
     cwd = Path.cwd()
     default_testdir = cwd / "testdata"

--- a/py/test_atlas_init/test_cli_tf/test_data/github_ci_logs/33721193952_tests-1.10.x-latest_tests-1.10.x-latest-false_advanced_cluster.txt
+++ b/py/test_atlas_init/test_cli_tf/test_data/github_ci_logs/33721193952_tests-1.10.x-latest_tests-1.10.x-latest-false_advanced_cluster.txt
@@ -1,0 +1,29 @@
+
+2024-11-30T00:29:50.3187240Z === RUN   TestMigAdvancedCluster_replicaSetAWSProviderUpdate
+2024-11-30T00:29:50.3188041Z === PAUSE TestMigAdvancedCluster_replicaSetAWSProviderUpdate
+2024-11-30T03:42:19.1303494Z 2024-11-30T03:42:19.129Z [ERROR] sdk.proto: Response contains error diagnostic: tf_resource_type=mongodbatlas_advanced_cluster diagnostic_summary="error updating advanced cluster (test-acc-tf-c-2284726486720125565): timeout while waiting for state to become 'IDLE' (last state: 'UPDATING', timeout: 3h0m0s)" diagnostic_detail="" diagnostic_severity=ERROR tf_req_id=deb543ce-1caf-ed1a-a74a-dd1424295cc0 tf_provider_addr=registry.terraform.io/hashicorp/mongodbatlas tf_proto_version=6.7 tf_rpc=ApplyResourceChange
+2024-11-30T03:42:19.1370595Z 2024-11-30T03:42:19.136Z [ERROR] sdk.helper_resource: Unexpected error: test_name=TestMigAdvancedCluster_replicaSetAWSProviderUpdate test_step_number=2 test_terraform_path=/home/runner/work/_temp/2e7d5ae3-922a-4945-909a-d55712a0b676/terraform test_working_directory=/tmp/plugintest3335886395
+2024-11-30T03:42:19.1371851Z   error=
+2024-11-30T03:42:19.1372183Z   | Error running apply: exit status 1
+2024-11-30T03:42:19.1372446Z   | 
+2024-11-30T03:42:19.1373718Z   | Error: error updating advanced cluster (test-acc-tf-c-2284726486720125565): timeout while waiting for state to become 'IDLE' (last state: 'UPDATING', timeout: 3h0m0s)
+2024-11-30T03:42:19.1374493Z   | 
+2024-11-30T03:42:19.1374758Z   |   with mongodbatlas_advanced_cluster.test,
+2024-11-30T03:42:19.1375343Z   |   on terraform_plugin_test.tf line 12, in resource "mongodbatlas_advanced_cluster" "test":
+2024-11-30T03:42:19.1375970Z   |   12: \t\tresource "mongodbatlas_advanced_cluster" "test" {
+2024-11-30T03:42:19.1376394Z   | 
+2024-11-30T03:42:19.1376582Z   
+2024-11-30T03:42:19.1376900Z === NAME  TestMigAdvancedCluster_replicaSetAWSProviderUpdate
+2024-11-30T03:42:19.1377672Z     resource_advanced_cluster_migration_test.go:54: Step 2/2 error: Error running apply: exit status 1
+2024-11-30T03:42:19.1378293Z         
+2024-11-30T03:42:19.1379496Z         Error: error updating advanced cluster (test-acc-tf-c-2284726486720125565): timeout while waiting for state to become 'IDLE' (last state: 'UPDATING', timeout: 3h0m0s)
+2024-11-30T03:42:19.1380169Z         
+2024-11-30T03:42:19.1380501Z           with mongodbatlas_advanced_cluster.test,
+2024-11-30T03:42:19.1381257Z           on terraform_plugin_test.tf line 12, in resource "mongodbatlas_advanced_cluster" "test":
+2024-11-30T03:42:19.1381956Z           12: 		resource "mongodbatlas_advanced_cluster" "test" {
+2024-11-30T03:42:19.1382478Z         
+2024-11-30T03:46:31.7791056Z --- FAIL: TestMigAdvancedCluster_replicaSetAWSProviderUpdate (11801.39s)
+2024-11-30T03:46:31.7791559Z FAIL
+2024-11-30T03:46:31.7792010Z Deleting execution project: test-acc-tf-p-89310970549397495, id: 674a5c7be8f37b6adf43ad6d
+2024-11-30T03:46:32.2176991Z FAIL	github.com/mongodb/terraform-provider-mongodbatlas/internal/service/advancedcluster	11804.666s
+2024-11-30T03:46:32.2289468Z FAIL

--- a/py/test_atlas_init/test_cli_tf/test_mock_tf_log/test_mock_tf_log_TestAccClusterAdvancedCluster_basicTenant_log_.yaml
+++ b/py/test_atlas_init/test_cli_tf/test_mock_tf_log/test_mock_tf_log_TestAccClusterAdvancedCluster_basicTenant_log_.yaml
@@ -259,7 +259,7 @@ steps:
     - response_index: 89
       status: 202
       text: '{}'
-  - path: /api/atlas/v2/groups/{groupId}/clusters
+  - path: /api/atlas/v2/groups/{groupId}/clusters/
     method: GET
     version: '2024-08-05'
     text: ''


### PR DESCRIPTION
Ensure the package name prompt is mandatory in the `mock_tf_log_cmd` function. Extract normalization logic into a separate function for better clarity and add an additional test case to enhance test coverage.