### PR TITLE
Update AWS role names and version bump to 0.4.1

### DIFF
--- a/py/atlas_init/__init__.py
+++ b/py/atlas_init/__init__.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-VERSION = "0.4.0"
+VERSION = "0.4.1"
 
 
 def running_in_repo() -> bool:

--- a/tf/modules/cfn/cfn.tf
+++ b/tf/modules/cfn/cfn.tf
@@ -11,7 +11,7 @@ locals {
   resource_actions_yaml = file("${path.module}/resource_actions.yaml")
   services              = yamldecode(local.services_yaml)
   resource_actions      = yamldecode(local.resource_actions_yaml)
-  role_name             = "cfn-execution-role-${var.cfn_profile}"
+  role_name             = "mongodb-atlas-cfn-${var.cfn_profile}"
   iam_policy_statement = {
     Sid      = "Original"
     Action   = local.resource_actions

--- a/tf/modules/cloud_provider/cloud_provider.tf
+++ b/tf/modules/cloud_provider/cloud_provider.tf
@@ -22,7 +22,7 @@ resource "mongodbatlas_cloud_provider_access_authorization" "auth_role" {
 
 
 resource "aws_iam_role" "aws_role" {
-  name = "atlas_init_aws_role_${var.name_suffix}"
+  name = "mongodb-atlas-ainit-${var.name_suffix}"
 
   assume_role_policy = <<EOF
 {


### PR DESCRIPTION
Update role names for AWS resources to reflect the MongoDB Atlas context and increment the version to 0.4.1.